### PR TITLE
Send test status (pass/fail) to SauceLabs (2/2)

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -11,6 +11,7 @@ var _ = require('lodash');
 
 var browsers = require('./browsers');
 var sauce    = require('./sauce');
+var http     = require('http');
 
 /** WCT plugin that enables support for remote browsers via Sauce Labs. */
 module.exports = function(wct, pluginOptions) {
@@ -60,6 +61,29 @@ module.exports = function(wct, pluginOptions) {
         done();
       });
     });
+  });
+
+  wct.on('browser-end', function(def, error, stats, sessionId){
+    // Send the pass/fail info to sauce-labs if we are testing remotely
+    if(wct.options.plugins.sauce != {}){
+      var username = wct.options.plugins.sauce.username;
+      var accessKey = wct.options.plugins.sauce.accessKey;
+      var httpOpts = {
+        hostname: 'saucelabs.com',
+        method: 'PUT',
+        path: '/rest/v1/' + username + '/jobs/' + sessionId,
+        auth: username + ':' + accessKey,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      };
+      var data = {
+        passed: (stats.failing > 0 ? false : true)
+      };
+      var req = http.request(httpOpts);
+      req.write(JSON.stringify(data));
+      req.end();
+    }
   });
 
 };


### PR DESCRIPTION
This is the second part of a change that sends the pass/fail status to SauceLabs. The first part is in web-component-tester [here](https://github.com/Polymer/web-component-tester/pull/124).

This is something i wanted for my own use, but I wanted to send it back as it's a fairly small change.
