### PR TITLE
Trim down the # of default browsers

### DIFF
--- a/default-sauce-browsers.json
+++ b/default-sauce-browsers.json
@@ -12,6 +12,11 @@
 
   {
     "browserName": "chrome",
+    "platform":    "OS X 10.10",
+    "version":     "canary"
+  },
+  {
+    "browserName": "chrome",
     "platform":    "Windows 8.1",
     "version":     "beta"
   },
@@ -29,7 +34,7 @@
   {
     "browserName": "firefox",
     "platform":    "Linux",
-    "version":     ""
+    "version":     "beta"
   },
 
   {

--- a/default-sauce-browsers.json
+++ b/default-sauce-browsers.json
@@ -7,11 +7,6 @@
   {
     "browserName": "internet explorer",
     "platform":    "Windows 7",
-    "version":     "11"
-  },
-  {
-    "browserName": "internet explorer",
-    "platform":    "Windows 7",
     "version":     "10"
   },
 
@@ -22,16 +17,6 @@
   },
   {
     "browserName": "chrome",
-    "platform":    "Windows 8.1",
-    "version":     ""
-  },
-  {
-    "browserName": "chrome",
-    "platform":    "OS X 10.10",
-    "version":     ""
-  },
-  {
-    "browserName": "chrome",
     "platform":    "Linux",
     "version":     ""
   },
@@ -39,11 +24,6 @@
   {
     "browserName": "firefox",
     "platform":    "Windows 8.1",
-    "version":     ""
-  },
-  {
-    "browserName": "firefox",
-    "platform":    "OS X 10.10",
     "version":     ""
   },
   {


### PR DESCRIPTION
Reduction in default set of browsers to run:
- Duplicate versions are only present for Windows + either OS X or linux
- Drop IE11 + Win7
