### PR TITLE
Fix #13: Make Selenium listener port configurable

### DIFF
--- a/lib/sauce.js
+++ b/lib/sauce.js
@@ -37,6 +37,7 @@ function startTunnel(config, emitter, done) {
       tunnelIdentifier: uuid.v4(),
       logger:           emitter.emit.bind(emitter, 'log:debug'),
       logfile:          logPath,
+      port:             config.port
     };
     _.assign(connectOptions, config.tunnelOptions);
     var tunnelId = connectOptions.tunnelIdentifier;


### PR DESCRIPTION
The Sauce Connect binary defaults to starting up the Selenium
relay on port 4445, but exposes a flag to override the default
in cases where that port is already in use.  This allows users
to specify a `port` option in `wct.conf.js` to override the
default Selenium listener port when using wct with Sauce
Connect.
