### PR TITLE
Provide arguments to set the visibility, job number and job name

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -82,6 +82,9 @@ module.exports = function(wct, pluginOptions) {
 
     var payload = {
       passed: (stats.status === 'complete' && stats.failing === 0),
+      "public": pluginOptions.visibility,
+      build: parseInt(""+pluginOptions.buildNumber),
+      name: pluginOptions.jobName
     };
     wct.emit('log:debug', 'Updating sauce job', sessionId, payload);
 
@@ -103,6 +106,9 @@ function expandOptions(options) {
     username:  process.env.SAUCE_USERNAME,
     accessKey: process.env.SAUCE_ACCESS_KEY,
     tunnelId:  process.env.SAUCE_TUNNEL_ID,
+    buildNumber: process.env.TRAVIS_BUILD_NUMBER,
+    jobName: process.env.TRAVIS_JOB_ID,
+    visibility: "public"
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,18 @@
       "tunnelId": {
         "help": "Sauce Connect tunnel identifier.",
         "full": "sauce-tunnel-id"
+      },
+      "buildNumber": {
+        "help": "The build number tested by this test for the sauce labs REST API.",
+        "full": "build-number"
+      },
+      "jobName": {
+        "help": "Job name for the sauce labs REST API.",
+        "full": "job-name"
+      },
+      "visibility": {
+        "help": "Set job visibility to 'public', 'public restricted', 'share', 'team' or 'private'",
+        "full": "visibility"
       }
     }
   },


### PR DESCRIPTION
Give arguments to set the visibility, job number and job name of the test in sauce labs.

They are required to get the badgets without the unknown text.
