### PR TITLE
Enable usage with corporate proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "cleankill": "^1.0.0",
     "lodash": "^3.0.1",
     "request": "^2.53.0",
-    "sauce-connect-launcher": "^0.14.0",
+    "sauce-connect-launcher": "^0.15.1",
     "temp": "^0.8.1",
     "uuid": "^2.0.1"
   },


### PR DESCRIPTION
Updated sauce-connect-launcher dependency to enable usage with corporate proxy.

sauce-connect-launcher 0.15.1 has support for https_proxy and http_proxy environment variables and will probably resolve issue #5 .
