### PR TITLE
Allow explicit opt-out of postinstall download

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -39,8 +39,8 @@ function requireSauceConnectLauncher(done, attempt) {
 var sauce = require('../lib/sauce');
 
 // don't download our own sauce connect binary if travis is running the
-// sauce_connect addon
-if (!sauce.isTravisSauceConnectRunning()) {
+// sauce_connect addon, or they explicitly opt out via an environment variable
+if (!(sauce.isTravisSauceConnectRunning() || process.env.SKIP_WCT_SAUCE_POSTINSTALL_DOWNLOAD)) {
   console.log('Prefetching the Sauce Connect binary.');
 
   sauce.setSauceConnectDownloadVersion();


### PR DESCRIPTION
In environments where an internal npm mirror is used, with limited internet access, it becomes problematic to have files downloaded straight off the internet during install.

To alleviate this, I've added a flag to explicitly allow the install/post-install download of sauce connect to be skipped, so you can just install wct-sauce at first, and download sauce connect later as part of the wct test run.
