### PR TITLE
Update default travis browsers

### DIFF
--- a/travis-browsers.json
+++ b/travis-browsers.json
@@ -10,23 +10,13 @@
     "version":      "11"
   },
   {
-    "browserName":  "internet explorer",
-    "platform":     "Windows 7",
+    "browserName":  "safari",
+    "platform":     "OS X 10.1",
     "version":      "10"
   },
   {
     "browserName":  "safari",
     "platform":     "OS X 10.11",
     "version":      "9"
-  },
-  {
-    "browserName":  "safari",
-    "platform":     "OS X 10.10",
-    "version":      "8"
-  },
-  {
-    "browserName":  "safari",
-    "platform":     "OS X 10.9",
-    "version":      "7"
   }
 ]

--- a/travis-browsers.json
+++ b/travis-browsers.json
@@ -2,7 +2,7 @@
   {
     "browserName":  "microsoftedge",
     "platform":     "Windows 10",
-    "version":      ""
+    "version":      "14"
   },
   {
     "browserName":  "internet explorer",
@@ -11,7 +11,7 @@
   },
   {
     "browserName":  "safari",
-    "platform":     "OS X 10.1",
+    "platform":     "OS X 10.11",
     "version":      "10"
   },
   {


### PR DESCRIPTION
IE 10 is no longer supported, and we only support the most recent two versions of Safari