### PR TITLE
Sauce Linux support is bad

### DIFF
--- a/default-sauce-browsers.json
+++ b/default-sauce-browsers.json
@@ -20,26 +20,3 @@
     "platform":     "OS X 10.11",
     "version":      "9"
   },
-
-  {
-    "browserName":  "chrome",
-    "platform":     "Linux",
-    "version":      "dev"
-    },
-  {
-    "browserName":  "chrome",
-    "platform":     "Linux",
-    "version":      "beta"
-  },
-  {
-    "browserName":  "chrome",
-    "platform":     "Linux",
-    "version":      ""
-  },
-
-  {
-    "browserName":  "firefox",
-    "platform":     "Linux",
-    "version":      ""
-  }
-]

--- a/default-sauce-browsers.json
+++ b/default-sauce-browsers.json
@@ -20,3 +20,26 @@
     "platform":     "OS X 10.11",
     "version":      "9"
   },
+  {
+    "browserName":  "chrome",
+    "platform":     "Linux",
+    "version":      "dev"
+  },
+  
+  {
+    "browserName":  "chrome",
+    "platform":     "Windows 10",
+    "version":      "beta"
+  },
+  {
+    "browserName":  "chrome",
+    "platform":     "Windows 10",
+    "version":      ""
+  },
+
+  {
+    "browserName":  "firefox",
+    "platform":     "Windows 10",
+    "version":      ""
+  }
+]

--- a/default-sauce-browsers.json
+++ b/default-sauce-browsers.json
@@ -20,12 +20,12 @@
     "platform":     "OS X 10.11",
     "version":      "9"
   },
+  
   {
     "browserName":  "chrome",
     "platform":     "Linux",
     "version":      "dev"
   },
-  
   {
     "browserName":  "chrome",
     "platform":     "Windows 10",


### PR DESCRIPTION
Saucelabs has stopped updating linux VMs for chrome and firefox. Chrome stopped at 48 and Firefox stopped at 45.

You can confirm by looking at the [Platform Configurator](https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/) or using `wct -s 'Linux/chrome@55' -s 'Linux/firefox@50'`