### PR TITLE
Remove the 'dev' version name for Linux Chrome in default sauce browser config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Removed the Linux Chrome 'dev' version browser, which is not a thing that Sauce does.
+
 ## 2.0.0-pre.3 - 2017-11-27
 
 - Added Edge 15 to Travis browser list.

--- a/default-sauce-browsers.json
+++ b/default-sauce-browsers.json
@@ -25,11 +25,11 @@
     "platform":     "OS X 10.11",
     "version":      "9"
   },
-  
+
   {
     "browserName":  "chrome",
     "platform":     "Linux",
-    "version":      "dev"
+    "version":      ""
   },
   {
     "browserName":  "chrome",


### PR DESCRIPTION
Sauce just says the browser version "dev" doesn't exist and then ruins the test run.  Removing the version label allows default Chrome to be chosen for the platform and everyone is happy.