### PR TITLE
Prepared CHANGELOG for a 2.0.0-pre.4 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.0.0-pre.4 - 2018-01-09
+
 - Removed the Linux Chrome 'dev' version browser, which is not a thing that Sauce does.
 
 ## 2.0.0-pre.3 - 2017-11-27


### PR DESCRIPTION
## 2.0.0-pre.4 - 2018-01-09

 - Removed the Linux Chrome 'dev' version browser, which is not a thing that Sauce does.
 - [x] Updated CHANGELOG 