### PR TITLE
Prepared CHANGELOG for a 2.0.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.0.0 - 2018-01-09
+
 - Remove hardcoded Sauce Connect version
 
 ## 2.0.0-pre.4 - 2018-01-09


### PR DESCRIPTION
## 2.0.0 - 2018-01-09

 - Remove hardcoded Sauce Connect version